### PR TITLE
update crendentials for push

### DIFF
--- a/.github/workflows/build-nightly-branches.yaml
+++ b/.github/workflows/build-nightly-branches.yaml
@@ -31,6 +31,9 @@ jobs:
             git clone "$REPO_URL" /var/tmp/$REPO_NAME
             cd /var/tmp/$REPO_NAME
 
+            # Set remote URL with token for authentication
+            git remote set-url origin https://${{ secrets.GIT_HUB_USER_NAME }}:${{ secrets.GIT_HUB_USER_TOKEN }}@github.com/${{ github.repository }}
+
             # Create new branch
             git checkout main
             echo "Creating new branch ${{ inputs.SPACEFX_VERSION }}-nightly for $REPO_NAME"


### PR DESCRIPTION
Updated permissions to successfully push the newly created branch

Example workflow for `github-actions` `0.11.0-nightly` branch:
https://github.com/microsoft/azure-orbital-space-sdk-github-actions/actions/runs/10688567689/job/29628699737

<img width="684" alt="image" src="https://github.com/user-attachments/assets/76d0c454-ed8e-4139-86cf-4dcb3a0a23a7">
